### PR TITLE
feat: fake 백엔드 api 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,14 @@
       "error",
       { "devDependencies": ["**/*.test.*", "**/*.config.*", "src/test/**/*"] }
     ],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "variable",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow"
+      }
+    ],
     "react/function-component-definition": "off"
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,95 @@
+import type { Company, Post, Country } from '@/types';
+
+// 샘플 데이터
+const countries: Country[] = [
+  { code: 'US', name: 'United States' },
+  { code: 'DE', name: 'Germany' },
+];
+
+const companies: Company[] = [
+  {
+    id: 'c1',
+    name: 'Acme Corp',
+    country: 'US',
+    emissions: [
+      { yearMonth: '2024-01', source: 'electricity', emissions: 120 },
+      { yearMonth: '2024-02', source: 'electricity', emissions: 110 },
+      { yearMonth: '2024-03', source: 'electricity', emissions: 95 },
+      { yearMonth: '2024-01', source: 'gasoline', emissions: 45 },
+      { yearMonth: '2024-02', source: 'gasoline', emissions: 50 },
+      { yearMonth: '2024-03', source: 'gasoline', emissions: 42 },
+    ],
+  },
+  {
+    id: 'c2',
+    name: 'Globex',
+    country: 'DE',
+    emissions: [
+      { yearMonth: '2024-01', source: 'electricity', emissions: 80 },
+      { yearMonth: '2024-02', source: 'electricity', emissions: 105 },
+      { yearMonth: '2024-03', source: 'electricity', emissions: 120 },
+      { yearMonth: '2024-01', source: 'diesel', emissions: 35 },
+      { yearMonth: '2024-02', source: 'diesel', emissions: 40 },
+      { yearMonth: '2024-03', source: 'diesel', emissions: 38 },
+    ],
+  },
+];
+
+const posts: Post[] = [
+  {
+    id: 'p1',
+    title: 'Sustainability Report',
+    resourceUid: 'c1',
+    dateTime: '2024-02',
+    content: 'Quarterly CO2 update',
+  },
+  {
+    id: 'p2',
+    title: 'Green Initiative Update',
+    resourceUid: 'c2',
+    dateTime: '2024-03',
+    content: 'Monthly sustainability progress',
+  },
+];
+
+// 내부 상태 (메모리에서 관리)
+let _countries = [...countries];
+let _companies = [...companies];
+let _posts = [...posts];
+
+// 유틸리티 함수들
+const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+const jitter = () => 200 + Math.random() * 600;
+const maybeFail = () => Math.random() < 0.15;
+
+// API 함수들
+export async function fetchCountries(): Promise<Country[]> {
+  await delay(jitter());
+  return _countries;
+}
+
+export async function fetchCompanies(): Promise<Company[]> {
+  await delay(jitter());
+  return _companies;
+}
+
+export async function fetchPosts(): Promise<Post[]> {
+  await delay(jitter());
+  return _posts;
+}
+
+export async function createOrUpdatePost(
+  p: Omit<Post, 'id'> & { id?: string }
+): Promise<Post> {
+  await delay(jitter());
+  if (maybeFail()) throw new Error('Save failed');
+
+  if (p.id) {
+    _posts = _posts.map((x) => (x.id === p.id ? (p as Post) : x));
+    return p as Post;
+  }
+
+  const created = { ...p, id: crypto.randomUUID() };
+  _posts = [..._posts, created];
+  return created;
+}


### PR DESCRIPTION
# 가상 백엔드 api 추가

과제 명세에 따라 네트워크 지연 및 간헐적 실패를 시뮬레이션하는 가상 API를 추가합니다.